### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 _site
 .sass-cache
 .jekyll-metadata
+.DS_Store*


### PR DESCRIPTION
.DS_Store is a MacOS binary that doesn't have any use in a Git repo