### PR TITLE
Move James Bonham to alumni students

### DIFF
--- a/_data/students.yml
+++ b/_data/students.yml
@@ -7,13 +7,6 @@
 #  education2:
 #  education3:
 #  education4:
-- name: James Bonham
-  photo: JB.jpg
-  info: Bachelor's degree student
-  email: jbonham2@illinois.edu
-  number_educ: 0
-  education1:
-
 - name: "This could be you !"
   photo: rock.jpg
   info: See <a href="/NeubauerGroup/vacancies">openings</a> for more info

--- a/_pages/team.md
+++ b/_pages/team.md
@@ -189,15 +189,20 @@ permalink: /team/
   <tr>
     <td>Viviana Cavaliere</td>
     <td>Allison McCarn</td>
-    <td>Matthew Feickert</td>
+    <td>James Bonham</td>
   </tr>
   <tr>
     <td>Lulu Liu</td>
     <td>Phllip Chang</td>
-    <td>James Garcia</td>
+    <td>Matthew Feickert</td>
   </tr>
   <tr>
     <td>Anna Sfyrla</td>
+    <td></td>
+    <td>James Garcia</td>
+  </tr>
+  <tr>
+    <td></td>
     <td></td>
     <td>Ricardo Garcia</td>
   </tr>


### PR DESCRIPTION
Move James Bonham to alumni students

```
* Move James Bonham from current students to alumni students
   - The alumni are listed in alphabetical order, so need to pop James to the top and then move some other alumi down given the horizontal spacing used
```