### PR TITLE
Add ATLAS News on likelihood publication feat. Feickert

### DIFF
--- a/_data/news.yml
+++ b/_data/news.yml
@@ -1,3 +1,6 @@
+- date: 12. December 2019
+  headline: "ATLAS has released the first open likelihoods from an LHC experiment. Read the ATLAS News article <a href='https://atlas.cern/updates/atlas-news/new-open-likelihoods'> here</a>. <img src='https://atlas-public.web.cern.ch/sites/atlas-public.web.cern.ch/files/field/image/ATLAS-OpenLikelihoods-Mockup.jpg' class='img-responsive' style='max-width: 260px' />"
+
 - date: 14. August 2018
   headline: "ATLAS <a href='https://arxiv.org/abs/1808.02380'> paper</a> combining diboson (W/Z boson pairs or W/Z boson and a Higgs boson) resonances search results. See the ATLAS Physics Briefing <a href='https://atlas.cern/updates/physics-briefing/stronger-together-combining-searches'> here</a>. <img src='/neubauer-group.github.io/images/newspic/diboson_combo.png' class='img-responsive' style='max-width: 260px' />"
 


### PR DESCRIPTION
Add [ATLAS News article on first publication of open likelihoods](https://atlas.cern/updates/atlas-news/new-open-likelihoods) that features @matthewfeickert's contributions to it.